### PR TITLE
Setup workflows

### DIFF
--- a/.github/workflows/arduino-checks.yml
+++ b/.github/workflows/arduino-checks.yml
@@ -1,12 +1,21 @@
-name: "Arduino Checks"
+name: "Lint Arduino Sketch"
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  lint:
+  arduino-lint:
+    name: Lint Arduino Sketch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: arduino/arduino-lint-action@v1
+      - name: Checkout AutoBoard
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Lint Sketch
+        uses: arduino/arduino-lint-action@v1
         with:
           project-type: sketch
+          compliance: strict

--- a/.github/workflows/arduino-test-compile.yml
+++ b/.github/workflows/arduino-test-compile.yml
@@ -1,0 +1,25 @@
+name: Arduino Test Compile
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test_compile:
+    name: Test Compile Sketch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AutoBoard
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Compile Sketch
+        uses: ArminJo/arduino-test-compile@v3
+        with:
+          arduino-platform: arduino:samd
+          arduino-board-fqbn: arduino:samd:nano_33_iot
+          required-libraries: ""
+          cli-version: 0.13.0
+          sketch-names: "AutoBoard.ino"
+          set-build-path: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,49 @@
+name: Arduino Compile and Release
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '*.ino'
+      - '*.h'
+      - '*.pde'
+      - '*.cpp'
+      - '*.c'
+
+  workflow_dispatch:
+
+jobs:
+  compile_and_release:
+    name: Compile Sketch and Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AutoBoard
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Find Semantic Version Number
+        uses: paulhatch/semantic-version@v4.0.2
+        id: get_version
+        with:
+          change_path: "'*.ino' '*.h' '*.pde' '*.cpp' '*.c'"
+
+      - name: Compile Sketch
+        uses: ArminJo/arduino-test-compile@v3
+        with:
+          arduino-platform: arduino:samd
+          arduino-board-fqbn: arduino:samd:nano_33_iot
+          required-libraries: ""
+          cli-version: 0.13.0
+          sketch-names: "AutoBoard.ino"
+          set-build-path: true
+
+      - name: Publish (Pre-)Release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: /home/runner/AutoBoard/build/arduino.samd.nano_33_iot/*
+          prerelease: true
+          generate_release_notes: true
+          tag_name: ${{ steps.get_version.outputs.version_tag }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # AutoBoard
+
+[![CodeFactor](https://www.codefactor.io/repository/github/mregirouard/autoboard/badge)](https://www.codefactor.io/repository/github/mregirouard/autoboard)
+
 Code for the AutoBoard Arduino Nano 33 IOT.


### PR DESCRIPTION
Create Arduino test compiling and automatic release workflows
Modify Arduino lint workflow
Update `README.md` to include CodeFactor badge 

The checks `Lint Arduino Sketch` and `Test Compile Sketch` should pass before merging, as well as the [CodeFactor](https://www.codefactor.io/) check.

The `Compile Sketch and Create Release` workflow will run on pushes to `main`, and will compile the code for the Nano IoT 33 board, find the version number, tag the commit with it, and create a release under the tag. Changes to code files will be counted as "changes", editing the `README.md` file will not result in a patch bump.

Generally, commits should be minor versions, and should include `(MINOR)` in the body. Major versions should include `(MAJOR)`. If no such text is included, the `patch` will be incremented. Commits should be major or minor increments, with the only exception of bug fixes. This is in accordance with the [Semantic Versioning 2.0.0 standard](https://semver.org/spec/v2.0.0.html):

> Given a version number MAJOR.MINOR.PATCH, increment the:
> MAJOR version when you make incompatible API changes,
> MINOR version when you add functionality in a backwards compatible manner, and
> PATCH version when you make backwards compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.